### PR TITLE
call ctx.Next() immediately

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ func New(config ...Config) func(*fiber.Ctx) {
 		if rid == "" {
 			rid = cfg.Generator()
 		}
-		c.Next()
 		// Set X-Request-ID
 		c.Set(fiber.HeaderXRequestID, rid)
+
+		c.Next()
 	}
 }


### PR DESCRIPTION
It is useful to be able to access the X-Request-ID in each handler... e.g. to enrich upcoming log entites with the request identifier.

This Pull-Request moves the `ctx.Next()` a few lines to set the X-Request-ID.